### PR TITLE
remove height and border-radius change at :after

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.6.0",
     "placetobe-behaviors": "Placetobe/placetobe-behaviors",
-    "placetobe-styles": "Placetobe/placetobe-styles"
+    "placetobe-styles": "Placetobe/placetobe-styles",
+    "paper-slider": "#1.0.15"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/placetobe-campaign-progress-bar.html
+++ b/placetobe-campaign-progress-bar.html
@@ -25,6 +25,12 @@ Placetobe Campaign Progress Bar
         @apply(--placetobe-flex-layout--vertical-reverse)
       }
 
+      #slider-container {
+        width: 100%;
+        display: flex;
+        flex-direction: row;
+      }
+
       :host section h6 {
         @apply(--placetobe-flex-item--1);
       }
@@ -37,26 +43,34 @@ Placetobe Campaign Progress Bar
       }
 
       :host paper-slider {
-        width: 100%;
         margin-left: calc(-15px + calc(calc(var(--placetobe-margin)/4))*-1);
         margin-right: calc(-15px + calc(calc(var(--placetobe-margin)/4))*-1);
+        @apply --placetobe-flex-item--1;
+
         --paper-slider-knob-start-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
         --paper-slider-disabled-active-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
         --paper-slider-disabled-knob-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
         --paper-slider-container-color: var(--placetobe-campaign-progress-bar-background-color, white);
         --paper-slider-height: calc(var(--placetobe-margin)/2);
+        --paper-slider-pin-start-color: red;
+        --paper-slider-knob-start-border-color: var(--placetobe-campaign-progress-bar-background-color, white);
+        --paper-slider-knob-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
+        --paper-slider-pin-start-color:var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
       }
     </style>
 
     <section>
       <h6>[[currentlyFundedPercentage]]% behaald</h6>
-      <paper-slider
-        min="0"
-        max="100"
-        value="[[_progressBarPercentage]]"
-        immediate-value="[[_progressBarPercentage]]"
-        disabled
-      ></paper-slider>
+      <div id="slider-container">
+        <paper-slider
+          min="0"
+          max="100"
+          value="[[_progressBarPercentage]]"
+          immediate-value="[[_progressBarPercentage]]"
+          disabled
+        ></paper-slider>
+      </div>
+      
     </section>
   </template>
 

--- a/placetobe-campaign-progress-bar.html
+++ b/placetobe-campaign-progress-bar.html
@@ -27,8 +27,8 @@ Placetobe Campaign Progress Bar
 
       #slider-container {
         width: 100%;
-        display: flex;
-        flex-direction: row;
+        @apply --placetobe-flex-layout;
+        @apply --placetobe-flex-layout--horizontal;
       }
 
       :host section h6 {

--- a/placetobe-campaign-progress-bar.html
+++ b/placetobe-campaign-progress-bar.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../placetobe-styles/placetobe-styles.html">
 <link rel="import" href="../placetobe-behaviors/placetobe-styles-behavior.html">
+<link rel="import" href="../paper-slider/paper-slider.html">
 
 <!--
 `placetobe-campaign-progress-bar`
@@ -24,51 +25,39 @@ Placetobe Campaign Progress Bar
         @apply(--placetobe-flex-layout--vertical-reverse)
       }
 
-      :host section .container.
       :host section h6 {
         @apply(--placetobe-flex-item--1);
-      }
-
-      :host .container {
-        @apply(--placetobe-border-box);
-        @apply(--placetobe-border-radius);
-        background-color: var(--placetobe-campaign-progress-bar-background-color, white);
-        height: 9px;
-        width: 100%;
-      }
-
-      :host #progress-bar {
-        @apply(--placetobe-border-radius);
-        background-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
-        height: 100%;
-        position: relative;
-      }
-
-      :host #progress-bar:after {
-        position: absolute;
-        width: var(--placetobe-margin);
-        right: -9px;
-        top: -4px;
-        content: "";
-        background-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
       }
 
       :host h6 {
         @apply(--placetobe-font-body-serif);
         font-size: var(--placetobe-font-body-size--small);
         color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
-        margin: 6px 0;
+        margin: 0;
+      }
+
+      :host paper-slider {
+        width: 100%;
+        margin-left: calc(-15px + calc(calc(var(--placetobe-margin)/4))*-1);
+        margin-right: calc(-15px + calc(calc(var(--placetobe-margin)/4))*-1);
+        --paper-slider-knob-start-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
+        --paper-slider-disabled-active-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
+        --paper-slider-disabled-knob-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
+        --paper-slider-container-color: var(--placetobe-campaign-progress-bar-background-color, white);
+        --paper-slider-height: calc(var(--placetobe-margin)/2);
       }
     </style>
 
     <section>
       <h6>[[currentlyFundedPercentage]]% behaald</h6>
-      <div class="container">
-        <div id="progress-bar" style$="width:[[_progressBarPercentage]]%;"></div>
-      </div>
+      <paper-slider
+        min="0"
+        max="100"
+        value="[[_progressBarPercentage]]"
+        immediate-value="[[_progressBarPercentage]]"
+        disabled
+      ></paper-slider>
     </section>
-
-
   </template>
 
   <script>

--- a/placetobe-campaign-progress-bar.html
+++ b/placetobe-campaign-progress-bar.html
@@ -52,10 +52,6 @@ Placetobe Campaign Progress Bar
         --paper-slider-disabled-knob-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
         --paper-slider-container-color: var(--placetobe-campaign-progress-bar-background-color, white);
         --paper-slider-height: calc(var(--placetobe-margin)/2);
-        --paper-slider-pin-start-color: red;
-        --paper-slider-knob-start-border-color: var(--placetobe-campaign-progress-bar-background-color, white);
-        --paper-slider-knob-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
-        --paper-slider-pin-start-color:var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
       }
     </style>
 

--- a/placetobe-campaign-progress-bar.html
+++ b/placetobe-campaign-progress-bar.html
@@ -47,11 +47,9 @@ Placetobe Campaign Progress Bar
       :host #progress-bar:after {
         position: absolute;
         width: var(--placetobe-margin);
-        height: var(--placetobe-margin);
         right: -9px;
         top: -4px;
         content: "";
-        border-radius: 50%;
         background-color: var(--placetobe-campaign-progress-bar-tint-color, var(--placetobe-color-green));
       }
 


### PR DESCRIPTION
I don’t really see what :after does. Can remove altogether?
It causes, on Edge, to overwrite all progress-bar height and border radius declarations